### PR TITLE
Facilitate use of assemble script in assemble-and-restart.sh

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -4,11 +4,10 @@ set -eo pipefail
 
 # We now run the assembly script. If there is a custom one written in the
 # source files, we use that instead.
-if [ -f /opt/app-root/src/.s2i/bin/assemble ]; then
-    /opt/app-root/src/.s2i/bin/assemble
+if [ -f ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/assemble ]; then
+    ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/assemble
 elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
     rm -rf /opt/app-root/src/.git # ensure we don't copy git files since they can cause problems
-    cp -a /opt/app-root/src/. /tmp/src # java s2i expects the source to be under /tmp/src
     ${ODO_S2I_SCRIPTS_URL}/assemble
 else
     /usr/libexec/s2i/assemble

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -6,10 +6,10 @@ set -eo pipefail
 # source files, we use that instead.
 if [ -f /opt/app-root/src/.s2i/bin/assemble ]; then
     /opt/app-root/src/.s2i/bin/assemble
-elif [ -f /usr/local/s2i/assemble ]; then # java s2i
+elif [ -z "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
     rm -rf /opt/app-root/src/.git # ensure we don't copy git files since they can cause problems
     cp -a /opt/app-root/src/. /tmp/src # java s2i expects the source to be under /tmp/src
-    /usr/local/s2i/assemble
+    ${ODO_S2I_SCRIPTS_URL}/assemble
 else
     /usr/libexec/s2i/assemble
 fi

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -6,7 +6,7 @@ set -eo pipefail
 # source files, we use that instead.
 if [ -f /opt/app-root/src/.s2i/bin/assemble ]; then
     /opt/app-root/src/.s2i/bin/assemble
-elif [ -z "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
+elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
     rm -rf /opt/app-root/src/.git # ensure we don't copy git files since they can cause problems
     cp -a /opt/app-root/src/. /tmp/src # java s2i expects the source to be under /tmp/src
     ${ODO_S2I_SCRIPTS_URL}/assemble

--- a/run
+++ b/run
@@ -4,10 +4,10 @@ set -eo pipefail
 
 # We now run the run script. If there is a custom one written in the
 # source files, we use that instead.
-if [ -f /opt/app-root/src/.s2i/bin/run ]; then
-    exec /opt/app-root/src/.s2i/bin/run
-elif [ -f /usr/local/s2i/run ]; then # java s2i
-    exec /usr/local/s2i/run
+if [ -f ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/run ]; then
+    exec ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/run
+elif [ -f ${ODO_S2I_SCRIPTS_URL}/run ]; then # java s2i
+    exec ${ODO_S2I_SCRIPTS_URL}/run
 else
     exec /usr/libexec/s2i/run
 fi

--- a/s2i-setup
+++ b/s2i-setup
@@ -5,9 +5,19 @@ set -eo pipefail
 # We need to setup these directories before the actual assembly process
 # because odo copies into some of these directories before running assemble
 
+# source directory from other s2i images
+mkdir -p ${ODO_S2I_SRC_BIN_PATH}
 # s2i fails when /tmp/src/ is empty. Also this is needed for Java s2i
-mkdir -p /tmp/src
+touch ${ODO_S2I_SRC_BIN_PATH}/.dummy
+
+# NodeJs s2i expects /tmp to exist even when its neither destination nor deployments-dir
+mkdir -p /tmp/src/
 touch /tmp/src/.dummy
 
-# source directory from other s2i images
+# some s2i images additionally expect ${ODO_S2I_SRC_BIN_PATH}/src to exist ex: /tmp/src for java
+if [[ ${ODO_S2I_SRC_BIN_PATH} != *"/src"* ]];then
+  mkdir -p ${ODO_S2I_SRC_BIN_PATH}/src
+  touch ${ODO_S2I_SRC_BIN_PATH}/src/.dummy
+fi
+
 mkdir -p /opt/app-root/src


### PR DESCRIPTION
Autodetect path for assemble and run scripts

Odo hardcodes the S2I assemble script path in
`https://github.com/redhat-developer/odo-supervisord-image/blob/master/assemble-and-restart`
But the S2I docs suggest that the S2I scripts need to looked up in the
following order:
1. A script found at the --scripts-url URL
2. A script found in the application source .s2i/bin directory
3. A script found at the default image URL (io.openshift.s2i.scripts-url label)
and ultimately giveup if not found in any of the above paths.

While, 1 is not relevant to us(builds triggered internally by odo), 2 is already
done by odo, 3 is enhanced by this PR instead of using the currently(without this PR)
hard-coded path

This PR uses the env vars passed by odo due to 
`https://github.com/redhat-developer/odo/pull/924` for running assemble script.

Note: The S2I scripts suggest that the builder image might point to any of the following
paths:

a. image://path_to_scripts_dir - absolute path inside the image
b. file://path_to_scripts_dir - relative or absolute path on the host machine
c. http(s)://path_to_scripts_dir - URL to a directory

Of these, the assemble-and-restart script is with this PR currently capable of handling
`image://path_to_scripts_dir` but not `file://` or `http(s)://` and they are expected to be
added over time. At the moment for any of the `file://` or `http(s)://`, the component
create and/or update is expected to fail as it is expected to be even with latest master.

To test:
Please refer https://github.com/redhat-developer/odo/pull/924 steps to test

fixes: redhat-developer/odo#869
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>