### PR TITLE
Run cp in non verbose mode

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -21,7 +21,7 @@ if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
     if [ ! -d /opt/app-root/backup ]; then
         mkdir -p /opt/app-root/backup
     fi
-   cp -rvf ${ODO_S2I_DEPLOYMENT_DIR}/* /opt/app-root/backup/
+   cp -rf ${ODO_S2I_DEPLOYMENT_DIR}/* /opt/app-root/backup/
 fi
 ####
 

--- a/run
+++ b/run
@@ -7,7 +7,7 @@ set -eo pipefail
 # copy content from /opt/app-root/backup directory to "ODO_S2I_DEPLOYMENT_DIR"
 # Ref: https://github.com/redhat-developer/odo/issues/445
 if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
-    cp -rvf /opt/app-root/backup/* ${ODO_S2I_DEPLOYMENT_DIR}/
+    cp -rf /opt/app-root/backup/* ${ODO_S2I_DEPLOYMENT_DIR}/
 fi
 ###
 


### PR DESCRIPTION
for bigger projects `cp -v` is polluting logs with a lot of useless information