### PR TITLE
Fix the failed to mv error on python s2i

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -2,6 +2,32 @@
 set -x
 set -eo pipefail
 
+# If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir injected by odo
+if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+    # If ODO_SRC_BACKUP_DIR is injected by odo
+    if [ -n  "$ODO_SRC_BACKUP_DIR" ]; then
+        # If it doesn't exit create it
+        if [ ! -d ${ODO_SRC_BACKUP_DIR} ]; then
+            mkdir -p ${ODO_SRC_BACKUP_DIR}/src
+        fi
+        # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR bcoz the assemble script for some s2i images
+        # moves sources from DestinationDir to WorkingDir thereby deleting it there(DestinationDir). So, back it up
+        # for partial push use cases like watch
+        rsync -r ${ODO_S2I_SRC_BIN_PATH}/src/. ${ODO_SRC_BACKUP_DIR}/src/
+    fi
+    # Clear all those dirs in WorkingDir that exist in DestinationDir so that when assemble script moves sources from
+    # DestinationDir to WorkingDir, it sees the directory clean and doesn't complain:
+    # https://github.com/redhat-developer/odo/issues/1054
+    for file in `ls -a ${ODO_S2I_SRC_BIN_PATH}/src/`
+    do
+        if [ $file != "." ] && [ $file != ".." ]; then
+            rm -fr $ODO_S2I_WORKING_DIR/$file
+        fi
+    done
+    # In case of java clear off the target directory
+    rm -fr ${ODO_S2I_SRC_BIN_PATH}/src/target
+fi
+
 # We now run the assembly script. If there is a custom one written in the
 # source files, we use that instead.
 if [ -f ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/assemble ]; then
@@ -11,6 +37,12 @@ elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env v
     ${ODO_S2I_SCRIPTS_URL}/assemble
 else
     /usr/libexec/s2i/assemble
+fi
+
+# After assemble script is run(which delets sources from destination dir by doing mv of them to the WorkingDir) and if only its component created from source,
+# copy back the sources from Source backup dir to DestinationDir for subsequent push of only updates by watch
+if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+    rsync -r ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 
 ### 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -25,7 +25,9 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2
         fi
     done
     # In case of java clear off the target directory
-    rm -fr ${ODO_S2I_SRC_BIN_PATH}/src/target
+    if [ -n "$ODO_S2I_BUILDER_IMG" ] && [ "$ODO_S2I_BUILDER_IMG" == "redhat-openjdk-18/openjdk18-openshift" ]; then
+        rm -fr ${ODO_S2I_SRC_BIN_PATH}/src/target
+    fi
 fi
 
 # We now run the assembly script. If there is a custom one written in the

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -2,29 +2,46 @@
 set -x
 set -eo pipefail
 
-# If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir injected by odo
+# If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir
 if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+
     # If ODO_SRC_BACKUP_DIR is injected by odo
     if [ -n  "$ODO_SRC_BACKUP_DIR" ]; then
+
         # If it doesn't exit create it
         if [ ! -d ${ODO_SRC_BACKUP_DIR} ]; then
             mkdir -p ${ODO_SRC_BACKUP_DIR}/src
         fi
-        # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR bcoz the assemble script for some s2i images
+
+        # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR because the assemble script for some s2i images
         # moves sources from DestinationDir to WorkingDir thereby deleting it there(DestinationDir). So, back it up
         # for partial push use cases like watch
         rsync -r ${ODO_S2I_SRC_BIN_PATH}/src/. ${ODO_SRC_BACKUP_DIR}/src/
     fi
+
+    # Backup field separators and set it to \n to clean the destination dir of even those files and folders that have space in name
+    # the shell's ls -A interprets for some reason the space as a new line and hence including '\n' in IFS works-around it
+    b_IFS=$IFS
+    b_OFS=$OIFS
+
+    OIFS="$IFS"
+    IFS=$'\n'
+
     # Clear all those dirs in WorkingDir that exist in DestinationDir so that when assemble script moves sources from
     # DestinationDir to WorkingDir, it sees the directory clean and doesn't complain:
     # https://github.com/redhat-developer/odo/issues/1054
-    for file in `ls -a ${ODO_S2I_SRC_BIN_PATH}/src/`
+    for file in `ls -A ${ODO_S2I_SRC_BIN_PATH}/src/`
     do
-        if [ $file != "." ] && [ $file != ".." ]; then
-            rm -fr $ODO_S2I_WORKING_DIR/$file
-        fi
+            rm -fr "$ODO_S2I_WORKING_DIR/$file"
     done
+
+    # Restore OIFS and IFS to previous values
+    OIFS=$b_OFS
+    IFS=$b_IFS
+
     # In case of java clear off the target directory
+    # ToDo: This is a temporary hack to work-around the issue with openjdk s2i image.
+    # Eventually, idea is to try to make this generic and agnostic of any particular s2i image
     if [ -n "$ODO_S2I_BUILDER_IMG" ] && [ "$ODO_S2I_BUILDER_IMG" == "redhat-openjdk-18/openjdk18-openshift" ]; then
         rm -fr ${ODO_S2I_SRC_BIN_PATH}/src/target
     fi
@@ -52,10 +69,12 @@ fi
 # copy content of directory to /opt/app-root/backup directory
 # Ref: https://github.com/redhat-developer/odo/issues/445
 if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
+
     if [ ! -d /opt/app-root/backup ]; then
         mkdir -p /opt/app-root/backup
     fi
-   cp -rf ${ODO_S2I_DEPLOYMENT_DIR}/. /opt/app-root/backup/
+
+   rsync -r ${ODO_S2I_DEPLOYMENT_DIR}/. /opt/app-root/backup/
 fi
 ####
 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -66,15 +66,15 @@ fi
 
 ### 
 # Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
-# copy content of directory to /opt/app-root/backup directory
+# copy content of directory to ${ODO_DEPLOYMENT_BACKUP_DIR} directory
 # Ref: https://github.com/redhat-developer/odo/issues/445
 if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
 
-    if [ ! -d /opt/app-root/backup ]; then
-        mkdir -p /opt/app-root/backup
+    if [ ! -d "${ODO_DEPLOYMENT_BACKUP_DIR}" ]; then
+        mkdir -p ${ODO_DEPLOYMENT_BACKUP_DIR}
     fi
 
-   rsync -r ${ODO_S2I_DEPLOYMENT_DIR}/. /opt/app-root/backup/
+   rsync -r ${ODO_S2I_DEPLOYMENT_DIR}/. ${ODO_DEPLOYMENT_BACKUP_DIR}/
 fi
 ####
 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -3,7 +3,7 @@ set -x
 set -eo pipefail
 
 # If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir
-if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ] || [ "${ODO_S2I_DEPLOYMENT_DIR}" != "${ODO_S2I_WORKING_DIR}" ]); then
 
     # If ODO_SRC_BACKUP_DIR is injected by odo
     if [ -n  "$ODO_SRC_BACKUP_DIR" ]; then
@@ -60,7 +60,7 @@ fi
 
 # After assemble script is run(which delets sources from destination dir by doing mv of them to the WorkingDir) and if only its component created from source,
 # copy back the sources from Source backup dir to DestinationDir for subsequent push of only updates by watch
-if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ] || [ "${ODO_S2I_DEPLOYMENT_DIR}" != "${ODO_S2I_WORKING_DIR}" ]); then
     rsync -r ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -16,7 +16,7 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S
         # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR because the assemble script for some s2i images
         # moves sources from DestinationDir to WorkingDir thereby deleting it there(DestinationDir). So, back it up
         # for partial push use cases like watch
-        rsync -r ${ODO_S2I_SRC_BIN_PATH}/src/. ${ODO_SRC_BACKUP_DIR}/src/
+        rsync -a ${ODO_S2I_SRC_BIN_PATH}/src/. ${ODO_SRC_BACKUP_DIR}/src/
     fi
 
     # Backup field separators and set it to \n to clean the destination dir of even those files and folders that have space in name
@@ -61,7 +61,7 @@ fi
 # After assemble script is run(which delets sources from destination dir by doing mv of them to the WorkingDir) and if only its component created from source,
 # copy back the sources from Source backup dir to DestinationDir for subsequent push of only updates by watch
 if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ] || [ "${ODO_S2I_DEPLOYMENT_DIR}" != "${ODO_S2I_WORKING_DIR}" ]); then
-    rsync -r ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
+    rsync -a ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 
 ### 
@@ -74,7 +74,7 @@ if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
         mkdir -p ${ODO_DEPLOYMENT_BACKUP_DIR}
     fi
 
-   rsync -r ${ODO_S2I_DEPLOYMENT_DIR}/. ${ODO_DEPLOYMENT_BACKUP_DIR}/
+   rsync -a ${ODO_S2I_DEPLOYMENT_DIR}/. ${ODO_DEPLOYMENT_BACKUP_DIR}/
 fi
 ####
 

--- a/run
+++ b/run
@@ -4,10 +4,10 @@ set -eo pipefail
 
 ###
 # Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
-# copy content from /opt/app-root/backup directory to "ODO_S2I_DEPLOYMENT_DIR"
+# copy content from ${ODO_DEPLOYMENT_BACKUP_DIR} directory to "ODO_S2I_DEPLOYMENT_DIR"
 # Ref: https://github.com/redhat-developer/odo/issues/445
-if [ -d /opt/app-root/backup ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
-    cp -rf /opt/app-root/backup/. ${ODO_S2I_DEPLOYMENT_DIR}/
+if [ -d ${ODO_DEPLOYMENT_BACKUP_DIR} ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
+    rsync -r ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
 fi
 ###
 

--- a/run
+++ b/run
@@ -7,7 +7,7 @@ set -eo pipefail
 # copy content from ${ODO_DEPLOYMENT_BACKUP_DIR} directory to "ODO_S2I_DEPLOYMENT_DIR"
 # Ref: https://github.com/redhat-developer/odo/issues/445
 if [ -d ${ODO_DEPLOYMENT_BACKUP_DIR} ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
-    rsync -r ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
+    rsync -a ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
 fi
 ###
 


### PR DESCRIPTION
The error happens when the local component source contains
a directory by name s2i. This fix clears the $APP_ROOT of
all files and folders before the assemble script copies
over sources from $destination dir to $app-root so that
mv from assemble script does not compile that the folder
already exists

fixes https://github.com/redhat-developer/odo/issues/1054
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>