### PR TITLE
Fix the problem of attempts to build component w/o source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - ./scripts/testing.sh
         - ./scripts/oc-cluster.sh
         - oc login -u developer
-        - cd $GOPATH/src/github.com/redhat-developer/odo
+        - cd $GOPATH/src/github.com/openshift/odo
         - make bin
         - sudo cp odo /usr/bin/odo
         - make test-main-e2e
@@ -27,7 +27,7 @@ jobs:
         - ./scripts/testing.sh
         - ./scripts/oc-cluster.sh
         - oc login -u developer
-        - cd $GOPATH/src/github.com/redhat-developer/odo
+        - cd $GOPATH/src/github.com/openshift/odo
         - make bin
         - sudo cp odo /usr/bin/odo
         - travis_wait make test-cmp-e2e
@@ -39,7 +39,7 @@ jobs:
         - ./scripts/testing.sh
         - ./scripts/oc-cluster.sh
         - oc login -u developer
-        - cd $GOPATH/src/github.com/redhat-developer/odo
+        - cd $GOPATH/src/github.com/openshift/odo
         - make bin
         - sudo cp odo /usr/bin/odo
         - make test-java-e2e
@@ -51,7 +51,7 @@ jobs:
         - ./scripts/testing.sh
         - ./scripts/oc-cluster.sh
         - oc login -u developer
-        - cd $GOPATH/src/github.com/redhat-developer/odo
+        - cd $GOPATH/src/github.com/openshift/odo
         - make bin
         - sudo cp odo /usr/bin/odo
         - make test-source-e2e
@@ -63,7 +63,7 @@ jobs:
         - ./scripts/testing.sh
         - ./scripts/oc-cluster.sh service-catalog
         - oc login -u developer
-        - cd $GOPATH/src/github.com/redhat-developer/odo
+        - cd $GOPATH/src/github.com/openshift/odo
         - make bin
         - sudo cp odo /usr/bin/odo
         - make test-service-e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ADD assemble-and-restart ${SUPERVISORD_DIR}/bin
 # RUN ${SUPERVISORD_DIR}/bin/assemble
 ADD run ${SUPERVISORD_DIR}/bin
 ADD s2i-setup ${SUPERVISORD_DIR}/bin
-ADD setup-and-run ${SUPERVISORD_DIR}/bin
 
 RUN chgrp -R 0 ${SUPERVISORD_DIR}  && \
     chmod -R g+rwX ${SUPERVISORD_DIR} && \

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/openshiftdo/supervisord/status "Docker Repository on Quay")](https://quay.io/repository/openshiftdo/supervisord)
 
-Container image that is used for InitContainer that setups [ODO](https://github.com/redhat-developer/odo/) components.
+Container image that is used for InitContainer that setups [ODO](https://github.com/openshift/odo/) components.

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -2,6 +2,8 @@
 set -x
 set -eo pipefail
 
+sed -i -- 's/autostart=false/autostart=true/g' /var/lib/supervisord/conf/supervisor.conf
+
 # If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir(if not copying directly to working dir) and deployment dir is not working dir
 if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -31,7 +31,7 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2
 
     # Clear all those dirs in WorkingDir that exist in DestinationDir so that when assemble script moves sources from
     # DestinationDir to WorkingDir, it sees the directory clean and doesn't complain:
-    # https://github.com/redhat-developer/odo/issues/1054
+    # https://github.com/openshift/odo/issues/1054
     for file in `ls -A ${ODO_S2I_SRC_BIN_PATH}/src/`
     do
             rm -fr "$ODO_S2I_WORKING_DIR/$file"
@@ -69,7 +69,7 @@ fi
 ### 
 # Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
 # copy content of directory to ${ODO_DEPLOYMENT_BACKUP_DIR} directory
-# Ref: https://github.com/redhat-developer/odo/issues/445
+# Ref: https://github.com/openshift/odo/issues/445
 if [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
 
     if [ ! -d "${ODO_DEPLOYMENT_BACKUP_DIR}" ]; then

--- a/run
+++ b/run
@@ -5,7 +5,7 @@ set -eo pipefail
 ###
 # Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
 # copy content from ${ODO_DEPLOYMENT_BACKUP_DIR} directory to "ODO_S2I_DEPLOYMENT_DIR"
-# Ref: https://github.com/redhat-developer/odo/issues/445
+# Ref: https://github.com/openshift/odo/issues/445
 if [ -d ${ODO_DEPLOYMENT_BACKUP_DIR} ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
     rsync -rlO ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
 fi

--- a/scripts/testing.sh
+++ b/scripts/testing.sh
@@ -3,10 +3,10 @@
 set -e 
 
 # Get master Odo
-git clone https://github.com/redhat-developer/odo $GOPATH/src/github.com/redhat-developer/odo
+git clone https://github.com/openshift/odo $GOPATH/src/github.com/openshift/odo
 
 # Retrieve the version / what's currently being used as SupervisorD
-IMAGE=`cat $GOPATH/src/github.com/redhat-developer/odo/pkg/occlient/occlient.go | grep "defaultBootstrapperImage = " | cut -d \" -f2 | sed '/^\s*$/d'`
+IMAGE=`cat $GOPATH/src/github.com/openshift/odo/pkg/occlient/occlient.go | grep "defaultBootstrapperImage = " | cut -d \" -f2 | sed '/^\s*$/d'`
 
 # Build the container
 docker build -t $IMAGE .

--- a/setup-and-run
+++ b/setup-and-run
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-set -eo pipefail
-
-echo "Setting up"
-/var/lib/supervisord/bin/s2i-setup
-
-echo "Running"
-/var/lib/supervisord/bin/run

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,11 +1,12 @@
 [program:run]
-command = /var/lib/supervisord/bin/setup-and-run
+command = /var/lib/supervisord/bin/run
 stdout_logfile=/dev/stdout
 stdout_events_enabled=true
 stderr_logfile=/dev/stderr
 stderr_events_enabled=true
 stopasgroup=true
 killasgroup=true
+autostart=false
 
 [inet_http_server]
 port=localhost:9001


### PR DESCRIPTION
This PR fixes the problem of repeated faield attempts by
systemd to build the component when no source is pushed.
The fix is to leverage `autostart=false` initially and
then turn it on via assemble-and-restart script(when push
or watch is done).

fixes: redhat-developer/odo#1066
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>