### PR TITLE
Use custom innerloop scripts for java and nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,9 @@ COPY run ${ODO_TOOLS_DIR}/bin
 COPY s2i-setup ${ODO_TOOLS_DIR}/bin
 COPY setup-and-run ${ODO_TOOLS_DIR}/bin
 COPY vendor/fix-permissions  /usr/bin/fix-permissions
-COPY --from=gobuilder /tmp/supervisord ${SUPERVISORD_DIR}/bin/supervisord
-COPY language-scripts ${SUPERVISORD_DIR}/language-scripts/
+
+COPY language-scripts ${ODO_TOOLS_DIR}/language-scripts/
+COPY --from=gobuilder /tmp/getlanguage ${ODO_TOOLS_DIR}/bin/getlanguage
 
 RUN chgrp -R 0 ${ODO_TOOLS_DIR}  && \
     chmod -R g+rwX ${ODO_TOOLS_DIR} && \

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -2,6 +2,18 @@
 set -x
 set -eo pipefail
 
+export ODO_UTILS_DIR=/opt/odo
+export ODO_IMAGE_MAPPINGS_FILE=${ODO_UTILS_DIR}/language-scripts/image-mappings.json
+
+IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
+
+if [ ! -z "${IMAGE_LANG}" ]; then
+    ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-assemble
+    ${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run
+    exit
+fi
+
+
 # If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir(if not copying directly to working dir) and deployment dir is not working dir
 if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
 
@@ -66,5 +78,5 @@ fi
 
 
 # Restart supervisord in order to actualy run the application
-# This is a dumb way to start as supervisord does not have a restart function
-/opt/odo/bin/supervisord ctl stop run; /opt/odo/bin/supervisord ctl start run
+# This is a dumb way to restart as supervisord does not have a restart function
+${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -10,7 +10,7 @@ IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
 if [ ! -z "${IMAGE_LANG}" ]; then
     ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-assemble
     ${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run
-    exit
+    exit 0
 fi
 
 

--- a/get-language/getlanguage.go
+++ b/get-language/getlanguage.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// Lang stores list of image names associated to language
+type Lang struct {
+	Language string
+	Images   []string
+}
+
+type ImageMappings []Lang
+
+// GetLanguage returns language name name for associated to imageName
+func (im ImageMappings) GetLanguage(imageName string) string {
+	for _, lang := range im {
+		for _, image := range lang.Images {
+			if image == imageName {
+				return lang.Language
+			}
+		}
+	}
+	return ""
+}
+
+func main() {
+	// json file where all the mappings of language to image name is stored
+	// see ImageMappings for json structure
+	imageMappingFile := os.Getenv("ODO_IMAGE_MAPPINGS_FILE")
+
+	// name of the current image, we will try to find what language this is based on ImageMappings
+	imageName := os.Getenv("ODO_S2I_BUILDER_IMG")
+
+	var imageMappings ImageMappings
+
+	file, err := os.Open(imageMappingFile)
+	defer file.Close()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	mappings, err := ioutil.ReadAll(file)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = json.Unmarshal(mappings, &imageMappings)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	lang := imageMappings.GetLanguage(imageName)
+
+	fmt.Print(lang)
+}

--- a/get-language/getlanguage.go
+++ b/get-language/getlanguage.go
@@ -8,12 +8,20 @@ import (
 	"os"
 )
 
+// imageMappingsFileEnv is env variable that points to image-mappings.json file
+const imageMappingsFileEnv string = "ODO_IMAGE_MAPPINGS_FILE"
+
+// builderImageNameEnv in env variable with name of the image ("name" label on the image)
+const builderImageNameEnv string = "ODO_S2I_BUILDER_IMG"
+
 // Lang stores list of image names associated to language
 type Lang struct {
 	Language string
 	Images   []string
 }
 
+// ImageMappings hold mappings of language to image name
+// the structure represents image-mappings.json file
 type ImageMappings []Lang
 
 // GetLanguage returns language name name for associated to imageName
@@ -31,10 +39,10 @@ func (im ImageMappings) GetLanguage(imageName string) string {
 func main() {
 	// json file where all the mappings of language to image name is stored
 	// see ImageMappings for json structure
-	imageMappingFile := os.Getenv("ODO_IMAGE_MAPPINGS_FILE")
+	imageMappingFile := os.Getenv(imageMappingsFileEnv)
 
 	// name of the current image, we will try to find what language this is based on ImageMappings
-	imageName := os.Getenv("ODO_S2I_BUILDER_IMG")
+	imageName := os.Getenv(builderImageNameEnv)
 
 	var imageMappings ImageMappings
 

--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -1,0 +1,18 @@
+[
+    {
+        "language": "java",
+        "images": [
+            "redhat-openjdk-18/openjdk18-openshift",
+            "openjdk/openjdk-11-rhel8",
+            "openjdk/openjdk-11-rhel7"
+        ]
+    },
+    {
+        "language": "nodejs",
+        "images": [
+            "rhscl/nodejs-8-rhel7",
+            "rhoar-nodejs/nodejs-8",
+            "rhoar-nodejs/nodejs-10"
+        ]
+    }
+]

--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -1,13 +1,5 @@
 [
     {
-        "language": "java",
-        "images": [
-            "redhat-openjdk-18/openjdk18-openshift",
-            "openjdk/openjdk-11-rhel8",
-            "openjdk/openjdk-11-rhel7"
-        ]
-    },
-    {
         "language": "nodejs",
         "images": [
             "rhscl/nodejs-8-rhel7",

--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -6,5 +6,13 @@
             "rhoar-nodejs/nodejs-8",
             "rhoar-nodejs/nodejs-10"
         ]
+    },
+    {
+        "language": "java",
+        "images": [
+            "redhat-openjdk-18/openjdk18-openshift",
+            "openjdk/openjdk-11-rhel8",
+            "openjdk/openjdk-11-rhel7"
+        ]
     }
 ]

--- a/language-scripts/java/dev-assemble
+++ b/language-scripts/java/dev-assemble
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "java dev-assemble"

--- a/language-scripts/java/dev-assemble
+++ b/language-scripts/java/dev-assemble
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "java dev-assemble"
+# standard assemble script in s2i builder images usualy works fine
+exec /usr/local/s2i/assemble

--- a/language-scripts/java/dev-assemble
+++ b/language-scripts/java/dev-assemble
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+set -x
+
+# run normal assemble script
+exec "${ODO_S2I_SCRIPTS_URL}/assemble"

--- a/language-scripts/java/dev-assemble
+++ b/language-scripts/java/dev-assemble
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# standard assemble script in s2i builder images usualy works fine
-exec /usr/local/s2i/assemble

--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "java dev-run"
+# standard run script in s2i builder images usualy works fine
+exec /usr/local/s2i/run

--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "java dev-run"

--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -x
+
+DEBUG_PORT="${DEBUG_PORT:=49200}"
+
+# DEBUG_MODE is true by defualt, which means that the application will be started with remote debugging enabled.
+DEBUG_MODE="${DEBUG_MODE:=true}"
+
+if [ $DEBUG_MODE != "false" ]; then
+    export JAVA_OPTS="$JAVA_OPTS -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n"
+fi
+
+# run normal run s2i script
+exec "${ODO_S2I_SCRIPTS_URL}/run"

--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# standard run script in s2i builder images usualy works fine
-exec /usr/local/s2i/run

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "nodejs dev-assemble"

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -1,3 +1,77 @@
 #!/bin/bash
+set -e
+set -x
 
-echo "nodejs dev-assemble"
+cd /tmp/src
+
+source /usr/libexec/s2i/env
+
+REFRESH_WORKING_DIR=/tmp/refresh/
+PACKAGE_SHA_FILE=$REFRESH_WORKING_DIR/package.json.sha1
+mkdir -p $REFRESH_WORKING_DIR
+
+
+if [ ! -z $HTTP_PROXY ]; then
+	echo "---> Setting npm http proxy to $HTTP_PROXY"
+	npm config set proxy $HTTP_PROXY
+fi
+
+if [ ! -z $http_proxy ]; then
+	echo "---> Setting npm http proxy to $http_proxy"
+	npm config set proxy $http_proxy
+fi
+
+if [ ! -z $HTTPS_PROXY ]; then
+	echo "---> Setting npm https proxy to $HTTPS_PROXY"
+	npm config set https-proxy $HTTPS_PROXY
+fi
+
+if [ ! -z $https_proxy ]; then
+	echo "---> Setting npm https proxy to $https_proxy"
+	npm config set https-proxy $https_proxy
+fi
+
+if [ ! -z $NO_PROXY ]; then
+	echo "---> Setting npm no proxy config to $NO_PROXY"
+	npm config set no-proxy $NO_PROXY
+fi
+
+if [ ! -z $no_proxy ]; then
+	echo "---> Setting npm no proxy config to $no_proxy"
+	npm config set no-proxy $no_proxy
+fi
+
+# Change the npm registry mirror if provided
+if [ ! -z "$NPM_MIRROR" ]; then
+	echo "---> Setting the npm package mirror to $NPM_MIRROR"
+	npm config set registry $NPM_MIRROR
+fi
+
+echo "---> Building your Node application from source"
+
+
+# don't do anything if package.json is the same as the last time this script run
+if [ -f $PACKAGE_SHA_FILE ]; then
+    out=$(sha1sum -c $PACKAGE_SHA_FILE || true)
+    if [ "$out" == "package.json: OK" ]; then
+        echo "---> package.json is the same as last time, no changes needed."
+        exit 0
+    fi
+fi
+
+echo "---> package.json modified"
+sha1sum package.json > $PACKAGE_SHA_FILE
+
+
+if [ ! -z "$YARN_ENABLED" ]; then
+	echo "---> Using 'yarn install' with YARN_ARGS"
+	npx yarn install $YARN_ARGS
+else
+	echo "---> Installing dependencies"
+    echo "---> Using 'npm install'"
+    npm install
+
+    #do not fail when there is no build script
+    echo "---> Building in development mode"
+    npm run build --if-present
+fi

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -4,10 +4,11 @@ set -x
 
 cd /tmp/src
 
-source /usr/libexec/s2i/env
+NODE_ENV="${NODE_ENV:=development}"
 
 REFRESH_WORKING_DIR=/tmp/refresh/
 PACKAGE_SHA_FILE=$REFRESH_WORKING_DIR/package.json.sha1
+
 mkdir -p $REFRESH_WORKING_DIR
 
 
@@ -50,7 +51,7 @@ fi
 echo "---> Building your Node application from source"
 
 
-# don't do anything if package.json is the same as the last time this script run
+# don't do anything if package.json is the same as the last time this script was executed
 if [ -f $PACKAGE_SHA_FILE ]; then
     out=$(sha1sum -c $PACKAGE_SHA_FILE || true)
     if [ "$out" == "package.json: OK" ]; then

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "nodejs dev-run"

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -1,3 +1,22 @@
 #!/bin/bash
+set -e
+set -x
 
-echo "nodejs dev-run"
+cd /tmp/src
+
+source /usr/libexec/s2i/env
+
+NPM_RUN="${NPM_RUN:=start}"
+
+export GIT_COMMITTER_NAME="unknown"
+export and GIT_COMMITTER_EMAIL="unknown@localhost.com"
+git --version
+
+echo -e "Using Node.js version: $(node --version)"
+echo -e "Environment:"
+echo -e "  NODE_ENV=${NODE_ENV}"
+echo -e "Running as user $(id)"
+
+echo "Launching via npm..."
+exec npm run ${NPM_RUN}
+

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -4,20 +4,29 @@ set -x
 
 cd /tmp/src
 
-
-NPM_RUN="${NPM_RUN:=start}"
 NODE_ENV="${NODE_ENV:=development}"
+DEBUG_PORT="${DEBUG_PORT:=9229}"
 
+# DEBUG_MODE is true by defualt, which means that the application will be started with remote debugging enabled.
+DEBUG_MODE="${DEBUG_MODE:=true}"
 
 export GIT_COMMITTER_NAME="unknown"
-export and GIT_COMMITTER_EMAIL="unknown@localhost.com"
+export and GIT_COMMITTER_EMAIL="unknown@localhost"
 git --version
 
 echo -e "Using Node.js version: $(node --version)"
 echo -e "Environment:"
 echo -e "  NODE_ENV=${NODE_ENV}"
+echo -e "  DEBUG_PORT=${DEBUG_PORT}"
+echo -e "  DEBUG_MODE=${DEBUG_MODE}"
 echo -e "Running as user $(id)"
 
 echo "Launching via npm..."
-exec npm run ${NPM_RUN}
+
+# TODO: if users app doesn't have nodemon as a dev dependency it will take a long time to start it via npx
+if [ $DEBUG_MODE == "false" ]; then
+    exec npm run -d start
+else
+    exec npx nodemon --inspect=$DEBUG_PORT
+fi
 

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -4,9 +4,10 @@ set -x
 
 cd /tmp/src
 
-source /usr/libexec/s2i/env
 
 NPM_RUN="${NPM_RUN:=start}"
+NODE_ENV="${NODE_ENV:=development}"
+
 
 export GIT_COMMITTER_NAME="unknown"
 export and GIT_COMMITTER_EMAIL="unknown@localhost.com"

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -23,10 +23,10 @@ echo -e "Running as user $(id)"
 
 echo "Launching via npm..."
 
-# TODO: if users app doesn't have nodemon as a dev dependency it will take a long time to start it via npx
 if [ $DEBUG_MODE == "false" ]; then
     exec npm run -d start
 else
+    # TODO: if users app doesn't have nodemon as a dev dependency it will take a long time to start it via npx
     exec npx nodemon --inspect=$DEBUG_PORT
 fi
 

--- a/run
+++ b/run
@@ -2,6 +2,23 @@
 set -x
 set -eo pipefail
 
+export ODO_SUPERVISORD_DIR=/var/lib/supervisord/
+export ODO_IMAGE_MAPPINGS_FILE=${ODO_SUPERVISORD_DIR}/language-scripts/image-mappings.json
+
+IMAGE_LANG=`${ODO_SUPERVISORD_DIR}/bin/getlanguage`
+
+if [ ! -z "${IMAGE_LANG}" ]; then
+    exec ${ODO_SUPERVISORD_DIR}/language-scripts/${IMAGE_LANG}/dev-run
+fi
+
+###
+# Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
+# copy content from ${ODO_DEPLOYMENT_BACKUP_DIR} directory to "ODO_S2I_DEPLOYMENT_DIR"
+# Ref: https://github.com/openshift/odo/issues/445
+if [ -d ${ODO_DEPLOYMENT_BACKUP_DIR} ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
+    rsync -rlO ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
+fi
+###
 
 # We now run the run script. If there is a custom one written in the
 # source files, we use that instead.

--- a/run
+++ b/run
@@ -11,15 +11,6 @@ if [ ! -z "${IMAGE_LANG}" ]; then
     exec ${ODO_SUPERVISORD_DIR}/language-scripts/${IMAGE_LANG}/dev-run
 fi
 
-###
-# Check "ODO_S2I_DEPLOYMENT_DIR" environment variable and if it's present,
-# copy content from ${ODO_DEPLOYMENT_BACKUP_DIR} directory to "ODO_S2I_DEPLOYMENT_DIR"
-# Ref: https://github.com/openshift/odo/issues/445
-if [ -d ${ODO_DEPLOYMENT_BACKUP_DIR} ] && [ -n "$ODO_S2I_DEPLOYMENT_DIR" ]; then
-    rsync -rlO ${ODO_DEPLOYMENT_BACKUP_DIR}/. ${ODO_S2I_DEPLOYMENT_DIR}/
-fi
-###
-
 # We now run the run script. If there is a custom one written in the
 # source files, we use that instead.
 if [ -f ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/run ]; then

--- a/run
+++ b/run
@@ -2,13 +2,14 @@
 set -x
 set -eo pipefail
 
-export ODO_SUPERVISORD_DIR=/var/lib/supervisord/
-export ODO_IMAGE_MAPPINGS_FILE=${ODO_SUPERVISORD_DIR}/language-scripts/image-mappings.json
+export ODO_UTILS_DIR=/opt/odo
 
-IMAGE_LANG=`${ODO_SUPERVISORD_DIR}/bin/getlanguage`
+export ODO_IMAGE_MAPPINGS_FILE=${ODO_UTILS_DIR}/language-scripts/image-mappings.json
+
+IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
 
 if [ ! -z "${IMAGE_LANG}" ]; then
-    exec ${ODO_SUPERVISORD_DIR}/language-scripts/${IMAGE_LANG}/dev-run
+    exec ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-run
 fi
 
 # We now run the run script. If there is a custom one written in the


### PR DESCRIPTION
Changes in this PR are automatically built on[ quay.io](https://quay.io/repository/tomkral/odo-supervisord-image?tab=history) `quay.io/tkral/odo-supervisord-image:dev-scripts` for easier testing.


To use this image just set env variable `ODO_BOOTSTRAPPER_IMAGE`
```
export ODO_BOOTSTRAPPER_IMAGE=quay.io/tkral/odo-supervisord-image:dev-scripts

odo create nodejs 
odo push
```

To revert back to normal image
```
unset ODO_BOOTSTRAPPER_IMAGE
```


This update allows odo to define it's own `assemble`  and `run` scripts that are more "inner-loop friendly" than those in s2i builder images.
Inner-loop scripts are `dev-assemble` and `dev-run` similar to s2i scripts, and they are distributed using InitContainer similar to how odo injects supervisord into builder images.


`language-scripts/image-mappings.json` is a JSON file that controls what scripts should be used in a given image.



Small go program `getlanguage `is used to return language name based on mappings in the image-mappings.json file. This information is then used to execute dev-* scripts instead of build-in s2i scripts inside the image. If image name is not in the mapping file, the regular s2i scripts are executed.


image-mappings.json
```
    {
        "language": "nodejs",
        "images": [
            "rhscl/nodejs-8-rhel7",
            "rhoar-nodejs/nodejs-8",
            "rhoar-nodejs/nodejs-10"
        ]
    }
```

This means that in images that are named as `rhscl/nodejs-8-rhel7`, `rhoar-nodejs/nodejs-8`, `rhoar-nodejs/nodejs-10` the scripts in `language-scripts/nodejs` will be executed instead of s2i scripts build into the images.



This effects only image specified in image-mappings.json, every other image works as before.
