### PR TITLE
set JAVA_OPTIONS in java dev-run

### DIFF
--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -4,11 +4,12 @@ set -x
 
 DEBUG_PORT="${DEBUG_PORT:=49200}"
 
-# DEBUG_MODE is true by defualt, which means that the application will be started with remote debugging enabled.
+# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
 DEBUG_MODE="${DEBUG_MODE:=true}"
 
 if [ $DEBUG_MODE != "false" ]; then
     export JAVA_OPTS="$JAVA_OPTS -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n"
+    export JAVA_OPTIONS=$JAVA_OPTS
 fi
 
 # run normal run s2i script


### PR DESCRIPTION
Older openjdk s2i images are using `JAVA_OPTIONS` instead of `JAVA_OPTS`

This PR makes sure that we set both variables, so it works on older images as well as on new one.
