### PR TITLE
Fix nodejs and don't skip source backup

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -7,13 +7,6 @@ export ODO_IMAGE_MAPPINGS_FILE=${ODO_UTILS_DIR}/language-scripts/image-mappings.
 
 IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
 
-if [ ! -z "${IMAGE_LANG}" ]; then
-    ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-assemble
-    ${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run
-    exit 0
-fi
-
-
 # If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir(if not copying directly to working dir) and deployment dir is not working dir
 if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
 
@@ -63,6 +56,8 @@ fi
 # source files, we use that instead.
 if [ -f ${ODO_S2I_SRC_BIN_PATH}/src/.s2i/bin/assemble ]; then
     ${ODO_S2I_SRC_BIN_PATH}/src/.s2i/bin/assemble
+elif [ -n "${IMAGE_LANG}" ]; then
+    ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-assemble
 elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
     rm -rf /opt/app-root/src/.git # ensure we don't copy git files since they can cause problems
     ${ODO_S2I_SCRIPTS_URL}/assemble

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -1,15 +1,61 @@
 #!/bin/bash
+
 set -e
 set -x
 
-cd /tmp/src
+# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
+DEBUG_MODE="${DEBUG_MODE:=true}"
 
-NODE_ENV="${NODE_ENV:=development}"
+if [ "$DEBUG_MODE" == "true" ]; then
+	export DEV_MODE=true
+fi
 
 REFRESH_WORKING_DIR=/tmp/refresh/
 PACKAGE_SHA_FILE=$REFRESH_WORKING_DIR/package.json.sha1
-
 mkdir -p $REFRESH_WORKING_DIR
+
+#from: /usr/libexec/s2i/env
+# If NODE_ENV is not set by the user, then default to production.
+# User may also set DEV_MODE=true
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+# Set the environment for this build configuration to production by default.
+if [ "$NODE_ENV" == "production" ]; then
+  export DEV_MODE=false
+else
+  export DEV_MODE=true
+fi
+
+
+if [ "$DEV_MODE" == true ] ; then
+	set -x
+fi
+
+echo "---> Installing application source"
+cp -Rfp /tmp/src/. ./
+
+
+# don't do anything if package.json is the same as the last time this script was executed
+if [ "$DEV_MODE" == true  ] && [ -f $PACKAGE_SHA_FILE ]; then
+    out=$(sha1sum -c $PACKAGE_SHA_FILE || true)
+    if [ "$out" == "package.json: OK" ]; then
+        echo "---> package.json is the same as last time, no changes needed."
+		echo "---> Fix permissions on app-root"
+		fix-permissions /opt/app-root
+        exit 0
+    fi
+fi
+
+echo "---> package.json modified"
+sha1sum package.json > $PACKAGE_SHA_FILE
+
+
 
 
 if [ ! -z $HTTP_PROXY ]; then
@@ -49,19 +95,8 @@ if [ ! -z "$NPM_MIRROR" ]; then
 fi
 
 echo "---> Building your Node application from source"
-
-
-# don't do anything if package.json is the same as the last time this script was executed
-if [ -f $PACKAGE_SHA_FILE ]; then
-    out=$(sha1sum -c $PACKAGE_SHA_FILE || true)
-    if [ "$out" == "package.json: OK" ]; then
-        echo "---> package.json is the same as last time, no changes needed."
-        exit 0
-    fi
-fi
-
-echo "---> package.json modified"
-sha1sum package.json > $PACKAGE_SHA_FILE
+echo -e "Current git config"
+git config --list
 
 
 if [ ! -z "$YARN_ENABLED" ]; then
@@ -69,10 +104,37 @@ if [ ! -z "$YARN_ENABLED" ]; then
 	npx yarn install $YARN_ARGS
 else
 	echo "---> Installing dependencies"
-    echo "---> Using 'npm install'"
-    npm install
+	if [ "$DEV_MODE" == true ]; then
+		echo "---> Using 'npm install'"
+		npm install
 
-    #do not fail when there is no build script
-    echo "---> Building in development mode"
-    npm run build --if-present
+		#do not fail when there is no build script
+		echo "---> Building in development mode"
+		npm run build --if-present
+	else
+		HAS_BUILD=$(node -e "console.log(require('./package.json').scripts.build ? true : false)")
+
+		# check to see if there is a build script by inspecting the package.json
+		if [ "$HAS_BUILD" == true ]; then
+			# Do a npm install to get the dev depdencies
+			echo "---> Installing dev dependencies"
+			NODE_ENV=development npm install
+			#do not fail when there is no build script
+			echo "---> Building in production mode"
+			npm run build --if-present
+		else
+			echo "---> Using 'npm install -s --only=production'"
+			npm install -s --only=production
+		fi
+
+		#echo "---> Pruning the development dependencies"
+		#npm prune
+	fi
 fi
+
+
+#echo "---> Cleaning up npm cache"
+#rm -rf .npm
+
+echo "---> Fix permissions on app-root"
+fix-permissions /opt/app-root

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -49,10 +49,10 @@ cp -Rf /tmp/src/. ./
 if [ "$DEV_MODE" == true  ] && [ -f $PACKAGE_SHA_FILE ]; then
     out=$(sha1sum -c $PACKAGE_SHA_FILE || true)
     if [ "$out" == "package.json: OK" ]; then
-        echo "---> package.json is the same as last time, no changes needed."
+		echo "---> package.json is the same as last time, no changes needed."
 		echo "---> Fix permissions on app-root"
 		fix-permissions /opt/app-root
-        exit 0
+		exit 0
     fi
 fi
 

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -38,7 +38,11 @@ if [ "$DEV_MODE" == true ] ; then
 fi
 
 echo "---> Installing application source"
-cp -Rfp /tmp/src/. ./
+# Do not run it with -p (preserving  some attributes)
+# It causes it to fail with "cp: preserving times for './.': Operation not permitted" when files come from Windows
+#cp -Rfp /tmp/src/. ./
+cp -Rf /tmp/src/. ./
+
 
 
 # don't do anything if package.json is the same as the last time this script was executed

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -2,31 +2,87 @@
 set -e
 set -x
 
-cd /tmp/src
-
-NODE_ENV="${NODE_ENV:=development}"
-DEBUG_PORT="${DEBUG_PORT:=9229}"
-
-# DEBUG_MODE is true by defualt, which means that the application will be started with remote debugging enabled.
+# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
 DEBUG_MODE="${DEBUG_MODE:=true}"
 
-export GIT_COMMITTER_NAME="unknown"
-export and GIT_COMMITTER_EMAIL="unknown@localhost"
-git --version
-
-echo -e "Using Node.js version: $(node --version)"
-echo -e "Environment:"
-echo -e "  NODE_ENV=${NODE_ENV}"
-echo -e "  DEBUG_PORT=${DEBUG_PORT}"
-echo -e "  DEBUG_MODE=${DEBUG_MODE}"
-echo -e "Running as user $(id)"
-
-echo "Launching via npm..."
-
-if [ $DEBUG_MODE == "false" ]; then
-    exec npm run -d start
-else
-    # TODO: if users app doesn't have nodemon as a dev dependency it will take a long time to start it via npx
-    exec npx nodemon --inspect=$DEBUG_PORT
+if [ "$DEBUG_MODE" == "true" ]; then
+	export DEV_MODE=true
 fi
 
+
+#from: /usr/libexec/s2i/env
+# If NODE_ENV is not set by the user, then default to production.
+# User may also set DEV_MODE=true
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+# Set the environment for this build configuration to production by default.
+if [ "$NODE_ENV" == "production" ]; then
+  export DEV_MODE=false
+else
+  export DEV_MODE=true
+fi
+
+# from /usr/libexec/s2i/generate-container-user
+# Set current user in nss_wrapper
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+
+    NSS_WRAPPER_PASSWD=/opt/app-root/etc/passwd
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
+
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=libnss_wrapper.so
+    export LD_PRELOAD
+fi
+
+# actuall run script
+
+# Set the environment for this build configuration to production by default.
+if [ "$NODE_ENV" == "production" ]; then
+  export DEV_MODE=false
+else
+  export DEV_MODE=true
+  set -x
+fi
+
+export GIT_COMMITTER_NAME="unknown"
+export and GIT_COMMITTER_EMAIL="unknown@localhost.com"
+git --version
+
+# Runs the nodejs application server.
+run_node() {
+  echo -e "Using Node.js version: $(node --version)"
+  echo -e "Environment: \n\tDEV_MODE=${DEV_MODE}\n\tNODE_ENV=${NODE_ENV}\n\tDEBUG_PORT=${DEBUG_PORT}"
+  echo -e "Running as user $(id)"
+  if [ "$DEV_MODE" == true ]; then
+    # this has already been done in assemble
+    #echo "Installing dev dependencies..."
+    #npm install
+    echo "Launching via nodemon..."
+    exec npx nodemon --inspect="$DEBUG_PORT"
+  else
+    echo "Launching via npm..."
+    exec npm run -d $NPM_RUN
+  fi
+}
+
+# Allow debugging the builder image itself, by using:
+# $ docker run -it nodeshift/centos-s2i-nodejs --debug
+#
+[ "$1" == "--debug" ] && exec /bin/bash
+
+run_node

--- a/run
+++ b/run
@@ -8,14 +8,12 @@ export ODO_IMAGE_MAPPINGS_FILE=${ODO_UTILS_DIR}/language-scripts/image-mappings.
 
 IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
 
-if [ ! -z "${IMAGE_LANG}" ]; then
-    exec ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-run
-fi
-
 # We now run the run script. If there is a custom one written in the
 # source files, we use that instead.
 if [ -f ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/run ]; then
     exec ${ODO_S2I_SRC_BIN_PATH}/.s2i/bin/run
+elif [ ! -z "${IMAGE_LANG}" ]; then
+    exec ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-run
 elif [ -f ${ODO_S2I_SCRIPTS_URL}/run ]; then # java s2i
     exec ${ODO_S2I_SCRIPTS_URL}/run
 else


### PR DESCRIPTION
- Use nodejs assemble and run scripts that are closer to orignal versions.
- Do not skip the source backup part even if the custom dev-* scripts are
used.

related to https://github.com/openshift/odo/issues/2224