### PR TITLE
Detect component has not been build yet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ COPY --from=gobuilder /tmp/supervisord ${ODO_TOOLS_DIR}/bin/supervisord
 COPY assemble-and-restart ${ODO_TOOLS_DIR}/bin
 COPY run ${ODO_TOOLS_DIR}/bin
 COPY s2i-setup ${ODO_TOOLS_DIR}/bin
-COPY setup-and-run ${ODO_TOOLS_DIR}/bin
 COPY vendor/fix-permissions  /usr/bin/fix-permissions
 COPY language-scripts ${ODO_TOOLS_DIR}/language-scripts/
 

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -71,6 +71,9 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${O
     rsync -rlO ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 
+# Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
+PV_MNT_PT="/opt/app-root"
+sed -i 's/autostart=false/autostart=true/g' ${PV_MNT_PT}/conf/supervisor.conf
 
 # Restart supervisord in order to actualy run the application
 # This is a dumb way to restart as supervisord does not have a restart function

--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -3,6 +3,7 @@
         "language": "nodejs",
         "images": [
             "rhscl/nodejs-8-rhel7",
+            "rhscl/nodejs-10-rhel7",
             "rhoar-nodejs/nodejs-8",
             "rhoar-nodejs/nodejs-10",
             "bucharestgold/centos7-s2i-nodejs",

--- a/s2i-setup
+++ b/s2i-setup
@@ -5,6 +5,14 @@ set -eo pipefail
 # We need to setup these directories before the actual assembly process
 # because odo copies into some of these directories before running assemble
 
+# If not present, copy supervisor.conf from EmptyDir on to persistent volume mounted on "/opt/app-root"
+# This is to persist supervisor.conf across pod restarts
+PV_MNT_PT="/opt/app-root"
+ODO_UTILS_DIR="/opt/odo"
+if [ ! -f ${PV_MNT_PT}/conf/supervisor.conf ]; then
+  cp -rp ${ODO_UTILS_DIR}/conf ${PV_MNT_PT}
+fi
+
 # source directory from other s2i images
 mkdir -p ${ODO_S2I_SRC_BIN_PATH}
 # s2i fails when /tmp/src/ is empty. Also this is needed for Java s2i
@@ -20,4 +28,4 @@ if [[ ${ODO_S2I_SRC_BIN_PATH} != *"/src"* ]];then
   touch ${ODO_S2I_SRC_BIN_PATH}/src/.dummy
 fi
 
-mkdir -p /opt/app-root/src
+mkdir -p ${PV_MNT_PT}/src

--- a/setup-and-run
+++ b/setup-and-run
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-set -eo pipefail
-
-echo "Setting up"
-/opt/odo/bin/s2i-setup
-
-echo "Running"
-/opt/odo/bin/run

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,11 +1,12 @@
 [program:run]
-command = /opt/odo/bin/setup-and-run
+command = /opt/odo/bin/run
 stdout_logfile=/dev/stdout
 stdout_events_enabled=true
 stderr_logfile=/dev/stderr
 stderr_events_enabled=true
 stopasgroup=true
 killasgroup=true
+autostart=false
 
 [inet_http_server]
 port=localhost:9001


### PR DESCRIPTION
1. Move conf file from EmptyDir Vol to Persistent Volume (/opt/odo -> /opt/app-src)

2. On successful assemble, change autostart value from false to true
3. Change supervisord command to execute "run" script only, as "s2i-setup" is executed in go-init pre-hook

Fixes https://github.com/openshift/odo/issues/1066