### PR TITLE
replace DEBUG_MODE with DEV_MODE

### DIFF
--- a/language-scripts/java/dev-run
+++ b/language-scripts/java/dev-run
@@ -4,10 +4,10 @@ set -x
 
 DEBUG_PORT="${DEBUG_PORT:=49200}"
 
-# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
-DEBUG_MODE="${DEBUG_MODE:=true}"
+# DEV_MODE is true by default, which means that the application will be started with remote debugging enabled.
+DEV_MODE="${DEV_MODE:=true}"
 
-if [ $DEBUG_MODE != "false" ]; then
+if [ $DEV_MODE != "false" ]; then
     export JAVA_OPTS="$JAVA_OPTS -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n"
     export JAVA_OPTIONS=$JAVA_OPTS
 fi

--- a/language-scripts/nodejs/dev-assemble
+++ b/language-scripts/nodejs/dev-assemble
@@ -3,12 +3,9 @@
 set -e
 set -x
 
-# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
-DEBUG_MODE="${DEBUG_MODE:=true}"
+# DEV_MODE is true by default, which means that the application will be started with remote debugging enabled.
+DEV_MODE="${DEV_MODE:=true}"
 
-if [ "$DEBUG_MODE" == "true" ]; then
-	export DEV_MODE=true
-fi
 
 REFRESH_WORKING_DIR=/tmp/refresh/
 PACKAGE_SHA_FILE=$REFRESH_WORKING_DIR/package.json.sha1

--- a/language-scripts/nodejs/dev-run
+++ b/language-scripts/nodejs/dev-run
@@ -2,13 +2,8 @@
 set -e
 set -x
 
-# DEBUG_MODE is true by default, which means that the application will be started with remote debugging enabled.
-DEBUG_MODE="${DEBUG_MODE:=true}"
-
-if [ "$DEBUG_MODE" == "true" ]; then
-	export DEV_MODE=true
-fi
-
+# DEV_MODE is true by default, which means that the application will be started with remote debugging enabled.
+DEV_MODE="${DEV_MODE:=true}"
 
 #from: /usr/libexec/s2i/env
 # If NODE_ENV is not set by the user, then default to production.


### PR DESCRIPTION
use `DEV_MODE` env variable instead of `DEBUG_MODE`.
This will allow users to use odo debug even with images that are not officially supported by odo, but support `DEV_MODE`.
~~resolves~~ related to https://github.com/openshift/odo/issues/2409