### PR TITLE
updated nodejs images in image mappings

### DIFF
--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -2,12 +2,12 @@
     {
         "language": "nodejs",
         "images": [
-            "rhscl/nodejs-8-rhel7",
+            "centos/nodejs-10-centos7",
+            "centos/nodejs-12-centos7",
             "rhscl/nodejs-10-rhel7",
-            "rhoar-nodejs/nodejs-8",
-            "rhoar-nodejs/nodejs-10",
+            "rhscl/nodejs-12-rhel7",
             "bucharestgold/centos7-s2i-nodejs",
-            "centos/nodejs-8-centos7"
+            "nodeshift/centos7-s2i-nodejs"
         ]
     },
     {


### PR DESCRIPTION
- removed RHOAR images as they are no longer supported
- removed nodejs 8 rhscl image as it has been deprecated
- added nodejs 12 images as supported
related issue https://github.com/openshift/odo/issues/2603