### PR TITLE
Changes required for devfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,16 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS gobuilder
 RUN mkdir -p /go/src/github.com/ochinchina/supervisord
 ADD vendor/supervisord /go/src/github.com/ochinchina/supervisord
 WORKDIR /go/src/github.com/ochinchina/supervisord
-RUN go build -o /tmp/supervisord
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/supervisord
 
 RUN mkdir -p /go/src/github.com/openshift/odo-supervisord-image
 ADD get-language /go/src/github.com/openshift/odo-supervisord-image/get-language/
 WORKDIR /go/src/github.com/openshift/odo-supervisord-image/get-language
-RUN go build -o /tmp/getlanguage  getlanguage.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/getlanguage  getlanguage.go
 
 RUN mkdir -p /go/src/github.com/pablo-ruth/go-init
 ADD go-init/main.go /go/src/github.com/pablo-ruth/go-init/go-init.go
-RUN go build -o /tmp/go-init /go/src/github.com/pablo-ruth/go-init/go-init.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/go-init /go/src/github.com/pablo-ruth/go-init/go-init.go
 
 # Final image
 FROM registry.access.redhat.com/ubi7/ubi
@@ -38,12 +38,14 @@ ENV ODO_TOOLS_DIR /opt/odo-init/
 # SupervisorD
 RUN mkdir -p ${ODO_TOOLS_DIR}/conf ${ODO_TOOLS_DIR}/bin
 COPY supervisor.conf ${ODO_TOOLS_DIR}/conf/
+COPY devfile-supervisor.conf ${ODO_TOOLS_DIR}/conf/
 COPY --from=gobuilder /tmp/supervisord ${ODO_TOOLS_DIR}/bin/supervisord
 
 # Wrapper scripts
 COPY assemble-and-restart ${ODO_TOOLS_DIR}/bin
 COPY run ${ODO_TOOLS_DIR}/bin
 COPY s2i-setup ${ODO_TOOLS_DIR}/bin
+COPY devfile-command ${ODO_TOOLS_DIR}/bin
 COPY vendor/fix-permissions  /usr/bin/fix-permissions
 COPY language-scripts ${ODO_TOOLS_DIR}/language-scripts/
 

--- a/devfile-command
+++ b/devfile-command
@@ -19,12 +19,17 @@ runCommand(){
     if [ -z "$ODO_COMMAND_RUN" ]; then
         echo "ODO_COMMAND_RUN is not set";
     else
+        CMD=""
         echo "ODO_COMMAND_RUN is $ODO_COMMAND_RUN";
         if [ ! -z $ODO_COMMAND_RUN_WORKING_DIR ]; then
             echo "Changing directory to $ODO_COMMAND_RUN_WORKING_DIR";
-            cd $ODO_COMMAND_RUN_WORKING_DIR
+            CMD="cd $ODO_COMMAND_RUN_WORKING_DIR"
         fi
-        sh -c "$ODO_COMMAND_RUN"
+        
+        CMD="$CMD && $ODO_COMMAND_RUN"
+        echo "Executing command $CMD"
+        # Need to execute commands this way in order for variable substitution to work
+        sh -c "$CMD"
     fi
 }
 
@@ -32,12 +37,17 @@ debugCommand(){
     if [ -z "$ODO_COMMAND_DEBUG" ]; then
         echo "ODO_COMMAND_DEBUG is not set";
     else
+        CMD=""
         echo "ODO_COMMAND_DEBUG is $ODO_COMMAND_DEBUG";
         if [ ! -z $ODO_COMMAND_DEBUG_WORKING_DIR ]; then
             echo "Changing directory to $ODO_COMMAND_DEBUG_WORKING_DIR";
-            cd $ODO_COMMAND_DEBUG_WORKING_DIR
+            CMD="cd $ODO_COMMAND_DEBUG_WORKING_DIR"
         fi
-        sh -c "$ODO_COMMAND_DEBUG"
+        
+        CMD="$CMD && $ODO_COMMAND_DEBUG"
+        echo "Executing command $CMD"
+        # Need to execute commands this way in order for variable substitution to work
+        sh -c "$CMD"
     fi
 }
 

--- a/devfile-command
+++ b/devfile-command
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -e
+
+# possible parameters
+CMD_RUN=devrun
+CMD_DEBUG=devdebug
+
+usage(){
+    echo ""
+    echo "This script only accepts the following parameters:"
+    echo ""
+    echo "$CMD_RUN"
+    echo "$CMD_DEBUG"
+    echo ""
+}
+
+runCommand(){
+    if [ -z "$ODO_COMMAND_RUN" ]; then
+        echo "ODO_COMMAND_RUN is not set";
+    else
+        echo "ODO_COMMAND_RUN is $ODO_COMMAND_RUN";
+        if [ ! -z $ODO_COMMAND_RUN_WORKING_DIR ]; then
+            echo "Changing directory to $ODO_COMMAND_RUN_WORKING_DIR";
+            cd $ODO_COMMAND_RUN_WORKING_DIR
+        fi
+        sh -c "$ODO_COMMAND_RUN"
+    fi
+}
+
+debugCommand(){
+    if [ -z "$ODO_COMMAND_DEBUG" ]; then
+        echo "ODO_COMMAND_DEBUG is not set";
+    else
+        echo "ODO_COMMAND_DEBUG is $ODO_COMMAND_DEBUG";
+        if [ ! -z $ODO_COMMAND_DEBUG_WORKING_DIR ]; then
+            echo "Changing directory to $ODO_COMMAND_DEBUG_WORKING_DIR";
+            cd $ODO_COMMAND_DEBUG_WORKING_DIR
+        fi
+        sh -c "$ODO_COMMAND_DEBUG"
+    fi
+}
+
+case $1 in
+    $CMD_RUN)
+        runCommand
+        ;;
+    $CMD_DEBUG)
+        debugCommand
+        ;;
+    *)
+        echo "ERROR: unexpected parameter \"$1\""
+        usage
+        exit 1
+esac
+shift

--- a/devfile-command
+++ b/devfile-command
@@ -23,10 +23,10 @@ runCommand(){
         echo "ODO_COMMAND_RUN is $ODO_COMMAND_RUN";
         if [ ! -z $ODO_COMMAND_RUN_WORKING_DIR ]; then
             echo "Changing directory to $ODO_COMMAND_RUN_WORKING_DIR";
-            CMD="cd $ODO_COMMAND_RUN_WORKING_DIR"
+            CMD="cd $ODO_COMMAND_RUN_WORKING_DIR &&"
         fi
         
-        CMD="$CMD && $ODO_COMMAND_RUN"
+        CMD="$CMD $ODO_COMMAND_RUN"
         echo "Executing command $CMD"
         # Need to execute commands this way in order for variable substitution to work
         sh -c "$CMD"
@@ -41,10 +41,10 @@ debugCommand(){
         echo "ODO_COMMAND_DEBUG is $ODO_COMMAND_DEBUG";
         if [ ! -z $ODO_COMMAND_DEBUG_WORKING_DIR ]; then
             echo "Changing directory to $ODO_COMMAND_DEBUG_WORKING_DIR";
-            CMD="cd $ODO_COMMAND_DEBUG_WORKING_DIR"
+            CMD="cd $ODO_COMMAND_DEBUG_WORKING_DIR &&"
         fi
         
-        CMD="$CMD && $ODO_COMMAND_DEBUG"
+        CMD="$CMD $ODO_COMMAND_DEBUG"
         echo "Executing command $CMD"
         # Need to execute commands this way in order for variable substitution to work
         sh -c "$CMD"

--- a/devfile-supervisor.conf
+++ b/devfile-supervisor.conf
@@ -1,0 +1,24 @@
+[program:devrun]
+command=/opt/odo/bin/devfile-command devrun
+stdout_logfile=/dev/stdout
+stdout_events_enabled=true
+stderr_logfile=/dev/stderr
+stderr_events_enabled=true
+stopasgroup=true
+killasgroup=true
+autostart=false
+startretries=0
+
+[program:devdebug]
+command=/opt/odo/bin/devfile-command devdebug
+stdout_logfile=/dev/stdout
+stdout_events_enabled=true
+stderr_logfile=/dev/stderr
+stderr_events_enabled=true
+stopasgroup=true
+killasgroup=true
+autostart=false
+startretries=0
+
+[inet_http_server]
+port=localhost:9001


### PR DESCRIPTION
This PR adds a `devfile-supervisor.conf` file and a `devfile-command` script that will be injected into devfile component containers that will be used to execute devfile commands. Supervisord will be started with `devfile-supervisor.conf` which in turn calls the `devfile-command` script. For more details on how devfile support will make use of supervisord see https://github.com/openshift/odo/issues/2654

The supervisord binary wasn't launching in alpine linux containers. Since devfile support is meant to also expand support to images beyond standard S2I-based images I've also updated the build options for the go-init and supervisord binaries.

I had to build the go binaries using the `GOOS=linux GOARCH=amd64 CGO_ENABLED=0` options. See https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker for details


A note on commit 617658dc11311430ea0cea82dd4b88e68105c1ed:

We were seeing a problem where the `devfile-command` script was failing with an error:
```
k logs python-hello-world-5c4cc48687-fqdv5
time="2020-03-30T15:29:07Z" level=info msg="create process:devrun" 
time="2020-03-30T15:29:07Z" level=info msg="create process:devdebug" 
time="2020-03-30T15:29:12Z" level=debug msg="no auth required" 
time="2020-03-30T15:29:12Z" level=info msg="stop the program" program=devrun 
time="2020-03-30T15:29:12Z" level=info msg="stop the program" program=devdebug 
time="2020-03-30T15:29:12Z" level=info msg="force to kill the program" program=devdebug 
time="2020-03-30T15:29:12Z" level=info msg="force to kill the program" program=devrun 
time="2020-03-30T15:29:13Z" level=debug msg="no auth required" 
time="2020-03-30T15:29:13Z" level=debug msg="succeed to find process:devrun" 
time="2020-03-30T15:29:13Z" level=info msg="try to start program" program=devrun 
time="2020-03-30T15:29:13Z" level=info msg="success to start program" program=devrun 
ODO_COMMAND_RUN is python hello-world.py
Changing directory to ${CHE_PROJECTS_ROOT}/python-hello-world
/opt/odo/bin/devfile-command: 25: cd: can't cd to ${CHE_PROJECTS_ROOT}/python-hello-world
time="2020-03-30T15:29:14Z" level=debug msg="wait program exit" program=devrun 
time="2020-03-30T15:29:14Z" level=error msg="program stopped with error:exit status 2" program=devrun 
time="2020-03-30T15:29:14Z" level=info msg="Don't start the stopped program because its autorestart flag is false" program=devrun 
```

This was because the `ODO_COMMAND_RUN_WORKING_DIR` variable's value was `${CHE_PROJECTS_ROOT}/python-hello-world`. The container has the variable set, however, when trying to execute `cd $ODO_COMMAND_RUN_WORKING_DIR` within the script the `${CHE_PROJECTS_ROOT}` portion of the path was not being expanded. In order to work around it I had to wrap the command with `sh -c` and then `${CHE_PROJECTS_ROOT}` was expanded to `/projects` correctly.