### PR TITLE
Add more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,6 @@ jobs:
       name: "build image and push to quay.io/odo-dev/init-image-pr"
       script:
         - ./scripts/build-push-image.sh 
-    - stage: test
-      name: "core beta, java, source e2e tests"
-      script:
-        - ./scripts/testing.sh
-        - cd $GOPATH/src/github.com/openshift/odo
-        - ./scripts/oc-cluster.sh
-        - oc login -u developer
-        - make goget-tools
-        - make bin
-        - sudo cp odo /usr/bin/odo
-        - travis_wait make test-e2e-beta
-        - travis_wait make test-e2e-java
-        - travis_wait make test-e2e-source
-        - odo logout
 
     # Run a few odo integration tests
     - stage: test
@@ -43,7 +29,7 @@ jobs:
         - odo logout
 
     - stage: test
-      name: "preference, config and url command integration tests"
+      name: "preference, config, url and debug command integration tests"
       script:
         - ./scripts/testing.sh
         - cd $GOPATH/src/github.com/openshift/odo
@@ -54,22 +40,7 @@ jobs:
         - sudo cp odo /usr/bin/odo
         - travis_wait make test-cmd-pref-config
         - travis_wait make test-cmd-url
-        - odo logout
-
-    - stage: test
-      name: "watch, storage, app and push command integration tests"
-      script:
-        - ./scripts/testing.sh
-        - cd $GOPATH/src/github.com/openshift/odo
-        - ./scripts/oc-cluster.sh
-        - oc login -u developer
-        - make goget-tools
-        - make bin
-        - sudo cp odo /usr/bin/odo
-        - travis_wait make test-cmd-watch
-        - travis_wait make test-cmd-storage
-        - travis_wait make test-cmd-app
-        - travis_wait make test-cmd-push
+        - travis_wait make test-cmd-debug
         - odo logout
 
     - stage: test
@@ -85,4 +56,41 @@ jobs:
         - travis_wait make test-cmd-service
         - make test-cmd-link-unlink
         - travis_wait make test-cmd-cmp-sub
+        - odo logout
+
+    - stage: test
+      name: "watch, storage, app, project, push, devfile catalog, devfile create, devfile push command integration tests"
+      script:
+        - ./scripts/testing.sh
+        - cd $GOPATH/src/github.com/openshift/odo
+        - ./scripts/oc-cluster.sh
+        - oc login -u developer
+        - make goget-tools
+        - make bin
+        - sudo cp odo /usr/bin/odo
+        - travis_wait make test-cmd-watch
+        - travis_wait make test-cmd-storage
+        - travis_wait make test-cmd-app
+        - travis_wait make test-cmd-push
+        - travis_wait make test-cmd-project
+        - travis_wait make test-cmd-devfile-catalog
+        - travis_wait make test-cmd-devfile-create
+        - travis_wait make test-cmd-devfile-push
+        - travis_wait make test-cmd-devfile-watch
+        - odo logout
+
+    - stage: test
+      name: "core beta, java, source e2e tests"
+      script:
+        - ./scripts/testing.sh
+        - cd $GOPATH/src/github.com/openshift/odo
+        - ./scripts/oc-cluster.sh
+        - oc login -u developer
+        - make goget-tools
+        - make bin
+        - sudo cp odo /usr/bin/odo
+        - travis_wait make test-e2e-beta
+        - travis_wait make test-e2e-java
+        - travis_wait make test-e2e-source
+        - travis_wait make test-e2e-images
         - odo logout


### PR DESCRIPTION
There were some tests that were missing in comparison to upstream tests.

This updates the tests (hopefully they all pass!)

It also re-organizes it (they were out of order) in comparison to upstream .travis.yml

Closes https://github.com/openshift/odo-init-image/issues/55

Signed-off-by: Charlie Drage <charlie@charliedrage.com>