### PR TITLE
disable PR push to quay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ language: go
 
 jobs:
   include:
-    - stage: build image
-      name: "build image and push to quay.io/odo-dev/init-image-pr"
-      script:
-        - ./scripts/build-push-image.sh 
+    # not working due to security restrictions on travis
+    # secret env variables are not available for PR builds
+    #- stage: build image
+    #  name: "build image and push to quay.io/odo-dev/init-image-pr"
+    #  script:
+    #    - ./scripts/build-push-image.sh 
 
     # Run a few odo integration tests
     - stage: test


### PR DESCRIPTION
We can't safely push the image to quay because there is no way to securely provide login credentials for PR Travis jobs. This is only possible if PR is opened from the branch in the same repository.

https://docs.travis-ci.com/user/encryption-keys/