### PR TITLE
Build odo on go1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 
 language: go
+go: "1.12"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ services:
   - docker
 
 language: go
+# If you are adding any features that require a higher version of golang,
+# such as golang 1.13 for example, please contact maintainers to check of the
+# releasing systems can handle the newer versions.
 go: "1.12"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ services:
   - docker
 
 language: go
-# If you are adding any features that require a higher version of golang,
-# such as golang 1.13 for example, please contact maintainers to check of the
-# releasing systems can handle the newer versions.
+# If you are adding any features that require a higher version of golang, such as golang 1.13 for example,
+# please contact maintainers to check of the releasing systems can handle the newer versions.
 go: "1.12"
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Build Go stuff (SupervisorD, getlanguage and go-init)
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS gobuilder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS gobuilder
 
 RUN mkdir -p /go/src/github.com/ochinchina/supervisord
 ADD vendor/supervisord /go/src/github.com/ochinchina/supervisord

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 
 # Build Go stuff (SupervisorD, getlanguage and go-init)
 
+# If you are adding any features that require a higher version of golang, such as golang 1.13 for example,
+# please contact maintainers to check of the releasing systems can handle the newer versions.
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS gobuilder
 
 RUN mkdir -p /go/src/github.com/ochinchina/supervisord

--- a/scripts/testing.sh
+++ b/scripts/testing.sh
@@ -6,7 +6,7 @@ set -e
 git clone https://github.com/openshift/odo $GOPATH/src/github.com/openshift/odo
 
 # Retrieve the version / what's currently being used as SupervisorD
-IMAGE=`cat $GOPATH/src/github.com/openshift/odo/pkg/occlient/occlient.go | grep "defaultBootstrapperImage = " | cut -d \" -f2 | sed '/^\s*$/d'`
+IMAGE=`cat $GOPATH/src/github.com/openshift/odo/pkg/devfile/adapters/common/utils.go | grep "defaultBootstrapperImage = " | cut -d \" -f2 | sed '/^\s*$/d'`
 
 # Build the container
 docker build -t $IMAGE .


### PR DESCRIPTION
go version go1.11.13 linux/amd64 does not support ```os.UserHomeDir```
```
$ make bin
go build -ldflags="-w -X github.com/openshift/odo/pkg/version.GITCOMMIT=8f38f155b" cmd/odo/odo.go
# github.com/openshift/odo/pkg/util
pkg/util/util.go:975:14: undefined: os.UserHomeDir
make: *** [bin] Error 2
The command "make bin" exited with 2.
```

So building it on go1.12