### PR TITLE
[WIP] Make Supervisord conf path configurable

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -73,7 +73,7 @@ fi
 
 # Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
 if [ -z ${ODO_SUPERVISORD_CONF_PATH}]; then
-    export ODO_SUPERVISORD_CONF_PATH = "/opt/app-root/conf/supervisor.conf"
+    export ODO_SUPERVISORD_CONF_PATH="/opt/app-root/conf/supervisor.conf"
 fi
 
 sed -i 's/autostart=false/autostart=true/g' ${ODO_SUPERVISORD_CONF_PATH}

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -72,8 +72,11 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${O
 fi
 
 # Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
-PV_MNT_PT="/opt/app-root"
-sed -i 's/autostart=false/autostart=true/g' ${PV_MNT_PT}/conf/supervisor.conf
+if [ -z ${ODO_SUPERVISORD_CONF_PATH}]; then
+    export ODO_SUPERVISORD_CONF_PATH = "/opt/app-root/conf/supervisor.conf"
+fi
+
+sed -i 's/autostart=false/autostart=true/g' ${ODO_SUPERVISORD_CONF_PATH}
 
 # Restart supervisord in order to actualy run the application
 # This is a dumb way to restart as supervisord does not have a restart function


### PR DESCRIPTION
since s2i and devfile uses different supervisord conf path. default is always the old value, to make migration easier
It needs to be updated for https://github.com/openshift/odo/issues/3156