### PR TITLE
Added ODO_S2I_CONVERTED_DEVFILE env variable

### DIFF
--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -71,10 +71,12 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${O
     rsync -rlO ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 
-# Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
-PV_MNT_PT="/opt/app-root"
-sed -i 's/autostart=false/autostart=true/g' ${PV_MNT_PT}/conf/supervisor.conf
-
-# Restart supervisord in order to actualy run the application
-# This is a dumb way to restart as supervisord does not have a restart function
-${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run
+# For components converted to devfile, we don't need to run following steps. As this steps already run by devfile push code.
+if [ -z "${ODO_S2I_CONVERTED_DEVFILE}" ]; then
+    # Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
+    PV_MNT_PT="/opt/app-root"
+    sed -i 's/autostart=false/autostart=true/g' ${PV_MNT_PT}/conf/supervisor.conf
+    # Restart supervisord in order to actualy run the application
+    # This is a dumb way to restart as supervisord does not have a restart function
+    ${ODO_UTILS_DIR}/bin/supervisord ctl stop run; ${ODO_UTILS_DIR}/bin/supervisord ctl start run
+fi

--- a/s2i-setup
+++ b/s2i-setup
@@ -29,3 +29,11 @@ if [[ ${ODO_S2I_SRC_BIN_PATH} != *"/src"* ]];then
 fi
 
 mkdir -p ${PV_MNT_PT}/src
+
+# for converted components there is volume permission issue if we directly sync the source code to /tmp/src
+# devfile creates empty dir to sync source code, which has root ownership. if we directly sync code to /tmp/src
+# it would have root ownership and s2i-assemble script would fail for non root container.
+# To resolve this issue we are first syncing to another dir.
+if [ ! -z "${ODO_S2I_CONVERTED_DEVFILE}" ];then
+  rsync -ar /tmp/projects/ /tmp/src
+fi


### PR DESCRIPTION
To enable easy migration from s2i components to devfile,  ` ODO_S2I_CONVERTED_DEVFILE` environment variable is inserted to component while `odo utils convert-to-devfile`. There are some changes in script if this flag is enabled.