### PR TITLE
Adding ubi8/nodejs-12 image as supported

### DIFF
--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -8,6 +8,7 @@
             "rhscl/nodejs-12-rhel7",
             "bucharestgold/centos7-s2i-nodejs",
             "nodeshift/centos7-s2i-nodejs",
+            "ubi8/nodejs-12",
 
             "rhscl/nodejs-8-rhel7",
             "rhoar-nodejs/nodejs-8",


### PR DESCRIPTION
Adding ubi8/nodejs-12 image as supported because there is latest image difference between 4.5 and 4.6 cluster. More details are in issue https://github.com/openshift/odo/issues/4016 . There is also one pr on odo https://github.com/openshift/odo/pull/4070.