### PR TITLE
Add ubi8/openjdk-11 image as supported

### DIFF
--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -21,7 +21,8 @@
         "images": [
             "redhat-openjdk-18/openjdk18-openshift",
             "openjdk/openjdk-11-rhel8",
-            "openjdk/openjdk-11-rhel7"
+            "openjdk/openjdk-11-rhel7",
+            "ubi8/openjdk-11"
         ]
     }
 ]


### PR DESCRIPTION
Adding ubi8/openjdk-11 image as supported because there is latest image difference between 4.5 and 4.6 cluster. More details are in issue https://github.com/openshift/odo/issues/4138#issuecomment-723857666 . We need to open one pr in odo as well after init image release.