### PR TITLE
Adding ubi8/nodejs-14 as supported

### DIFF
--- a/language-scripts/image-mappings.json
+++ b/language-scripts/image-mappings.json
@@ -9,6 +9,7 @@
             "bucharestgold/centos7-s2i-nodejs",
             "nodeshift/centos7-s2i-nodejs",
             "ubi8/nodejs-12",
+            "ubi8/nodejs-14",
 
             "rhscl/nodejs-8-rhel7",
             "rhoar-nodejs/nodejs-8",


### PR DESCRIPTION
Adding ubi8/nodejs-14 image as supported to make sure nodejs latest on ocp 4.7 executes successfully. This will fix a part of https://github.com/openshift/odo/issues/4303 . There is one more pr https://github.com/openshift/odo/pull/4304 which is dependent on this pr

ping @kadel 