### PR TITLE
Cosmetic changes (80 chars in a line)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL com.redhat.component=odo-init-container \
     name=ocp-tools-4/odo-init-image \ 
     io.k8s.display-name=atomic-openshift-odo-init-image \
     maintainer=devtools-deploy@redhat.com \ 
-    summary="Odo init image is an init container used by odo to initialze a 'component'"
+    summary="odo init image is an init container used by odo to initialze a 'component'"
 
 # Change version as needed
 LABEL version=1.1.10

--- a/assemble-and-restart
+++ b/assemble-and-restart
@@ -7,35 +7,43 @@ export ODO_IMAGE_MAPPINGS_FILE=${ODO_UTILS_DIR}/language-scripts/image-mappings.
 
 IMAGE_LANG=`${ODO_UTILS_DIR}/bin/getlanguage`
 
-# If WorkingDir is injected as an env from odo and destination path is not equal to WorkingDir(if not copying directly to working dir) and deployment dir is not working dir
-if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
+# If WorkingDir is injected as an env from odo and destination path is not
+# equal to WorkingDir(if not copying directly to working dir) and deployment
+# dir is not working dir
+if [ -n "${ODO_S2I_WORKING_DIR}" ] && \
+    [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ]; then
 
     # If ODO_SRC_BACKUP_DIR is injected by odo
     if [ -n  "$ODO_SRC_BACKUP_DIR" ]; then
 
-        # If it doesn't exit create it
-        if [ ! -d ${ODO_SRC_BACKUP_DIR} ]; then
-            mkdir -p ${ODO_SRC_BACKUP_DIR}/src
+        # If it doesn't exist create it
+        if [ ! -d "${ODO_SRC_BACKUP_DIR}" ]; then
+            mkdir -p "${ODO_SRC_BACKUP_DIR}"/src
         fi
 
-        # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR because the assemble script for some s2i images
-        # moves sources from DestinationDir to WorkingDir thereby deleting it there(DestinationDir). So, back it up
-        # for partial push use cases like watch
-        rsync -rlO ${ODO_S2I_SRC_BIN_PATH}/src/. ${ODO_SRC_BACKUP_DIR}/src/
+        # Backup the sources in DestinationDir to ODO_SRC_BACKUP_DIR because
+        # the assemble script for some s2i images moves sources from
+        # DestinationDir to WorkingDir thereby deleting it
+        # there(DestinationDir). So, back it up for partial push use cases like
+        # watch
+        rsync -rlO "${ODO_S2I_SRC_BIN_PATH}"/src/. "${ODO_SRC_BACKUP_DIR}"/src/
     fi
 
-    # Backup field separators and set it to \n to clean the destination dir of even those files and folders that have space in name
-    # the shell's ls -A interprets for some reason the space as a new line and hence including '\n' in IFS works-around it
+    # Backup field separators and set it to \n to clean the destination dir of
+    # even those files and folders that have space in name the shell's ls -A
+    # interprets for some reason the space as a new line and hence including
+    # '\n' in IFS works-around it
     b_IFS=$IFS
     b_OFS=$OIFS
 
     OIFS="$IFS"
     IFS=$'\n'
 
-    # Clear all those dirs in WorkingDir that exist in DestinationDir so that when assemble script moves sources from
-    # DestinationDir to WorkingDir, it sees the directory clean and doesn't complain:
+    # Clear all those dirs in WorkingDir that exist in DestinationDir so that
+    # when assemble script moves sources from DestinationDir to WorkingDir, it
+    # sees the directory clean and doesn't complain:
     # https://github.com/openshift/odo/issues/1054
-    for file in `ls -A ${ODO_S2I_SRC_BIN_PATH}/src/`
+    for file in `ls -A "${ODO_S2I_SRC_BIN_PATH}"/src/`
     do
             rm -fr "$ODO_S2I_WORKING_DIR/$file"
     done
@@ -45,9 +53,11 @@ if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2
     IFS=$b_IFS
 
     # In case of java clear off the target directory
-    # ToDo: This is a temporary hack to work-around the issue with openjdk s2i image.
-    # Eventually, idea is to try to make this generic and agnostic of any particular s2i image
-    if [ -n "$ODO_S2I_BUILDER_IMG" ] && [ "$ODO_S2I_BUILDER_IMG" == "redhat-openjdk-18/openjdk18-openshift" ]; then
+    # ToDo: This is a temporary hack to work-around the issue with openjdk s2i
+    # image. Eventually, idea is to try to make this generic and agnostic of
+    # any particular s2i image
+    if [ -n "$ODO_S2I_BUILDER_IMG" ] && \
+        [ "$ODO_S2I_BUILDER_IMG" == "redhat-openjdk-18/openjdk18-openshift" ]; then
         rm -fr ${ODO_S2I_SRC_BIN_PATH}/src/target
     fi
 fi
@@ -58,22 +68,31 @@ if [ -f ${ODO_S2I_SRC_BIN_PATH}/src/.s2i/bin/assemble ]; then
     ${ODO_S2I_SRC_BIN_PATH}/src/.s2i/bin/assemble
 elif [ -n "${IMAGE_LANG}" ]; then
     ${ODO_UTILS_DIR}/language-scripts/${IMAGE_LANG}/dev-assemble
-elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then # For S2I scripts path, use the env var set by odo if not available in component source
+elif [ -n "${ODO_S2I_SCRIPTS_URL}" ]; then 
+    # For S2I scripts path, use the env var set by odo if not available in
+    # component source
     rm -rf /opt/app-root/src/.git # ensure we don't copy git files since they can cause problems
     ${ODO_S2I_SCRIPTS_URL}/assemble
 else
     /usr/libexec/s2i/assemble
 fi
 
-# After assemble script is run(which deletes sources from destination dir by doing mv of them to the WorkingDir) and if only its component created from source,
-# copy back the sources from Source backup dir to DestinationDir for subsequent push of only updates by watch
-if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ] && [ "${ODO_S2I_DEPLOYMENT_DIR}" != "${ODO_S2I_WORKING_DIR}" ]); then
+# After assemble script is run(which deletes sources from destination dir by
+# doing mv of them to the WorkingDir) and if only its component created from
+# source, copy back the sources from Source backup dir to DestinationDir for
+# subsequent push of only updates by watch
+if [ ! -z "${ODO_S2I_WORKING_DIR}" ] && [ -n  "$ODO_SRC_BACKUP_DIR" ] && \ 
+    ([ "${ODO_S2I_SRC_BIN_PATH}" != "${ODO_S2I_WORKING_DIR}" ] && \ 
+    [ "${ODO_S2I_DEPLOYMENT_DIR}" != "${ODO_S2I_WORKING_DIR}" ]); then 
     rsync -rlO ${ODO_SRC_BACKUP_DIR}/src/. ${ODO_S2I_SRC_BIN_PATH}/src/
 fi
 
-# For components converted to devfile, we don't need to run following steps. As this steps already run by devfile push code.
+# For components converted to devfile, we don't need to run following steps. As
+# this steps already run by devfile push code.
 if [ -z "${ODO_S2I_CONVERTED_DEVFILE}" ]; then
-    # Now that the assemble is successful; change autostart from false to true in supervisor.conf present on persistent volume mounted on "/opt/app-root"
+    # Now that the assemble is successful; change autostart from false to true
+    # in supervisor.conf present on persistent volume mounted on
+    # "/opt/app-root"
     PV_MNT_PT="/opt/app-root"
     sed -i 's/autostart=false/autostart=true/g' ${PV_MNT_PT}/conf/supervisor.conf
     # Restart supervisord in order to actualy run the application

--- a/devfile-command
+++ b/devfile-command
@@ -21,7 +21,7 @@ runCommand(){
     else
         CMD=""
         echo "ODO_COMMAND_RUN is $ODO_COMMAND_RUN";
-        if [ ! -z $ODO_COMMAND_RUN_WORKING_DIR ]; then
+        if [ -n "$ODO_COMMAND_RUN_WORKING_DIR" ]; then
             echo "Changing directory to $ODO_COMMAND_RUN_WORKING_DIR";
             CMD="cd $ODO_COMMAND_RUN_WORKING_DIR &&"
         fi
@@ -39,7 +39,7 @@ debugCommand(){
     else
         CMD=""
         echo "ODO_COMMAND_DEBUG is $ODO_COMMAND_DEBUG";
-        if [ ! -z $ODO_COMMAND_DEBUG_WORKING_DIR ]; then
+        if [ -n "$ODO_COMMAND_DEBUG_WORKING_DIR" ]; then
             echo "Changing directory to $ODO_COMMAND_DEBUG_WORKING_DIR";
             CMD="cd $ODO_COMMAND_DEBUG_WORKING_DIR &&"
         fi


### PR DESCRIPTION
Some minor cosmetic changes that I found worth doing while going through the code:
1. 80 characters in a single line because long comments/code become painful to comprehend
2. `s/Odo/odo` at one place.
3. `s/exit/eixst` at one place.
4. Add double quotes around variable names
5. Use `-n` instead of `! -z` based on https://github.com/koalaman/shellcheck/wiki/SC2236 (auto suggested by GoLand)