### PR TITLE
Autostart dev when project directory is not empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 
 # Build Go stuff (SupervisorD, getlanguage and go-init)
 
-# If you are adding any features that require a higher version of golang, such as golang 1.13 for example,
+# If you are adding any features that require a higher version of golang, such as golang 1.16 for example,
 # please contact maintainers to check of the releasing systems can handle the newer versions.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS gobuilder
+FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS gobuilder
 
 RUN mkdir -p /go/src/github.com/ochinchina/supervisord
 ADD vendor/supervisord /go/src/github.com/ochinchina/supervisord

--- a/devfile-command
+++ b/devfile-command
@@ -16,6 +16,11 @@ usage(){
 }
 
 runCommand(){
+    # test if project directory is empty. If so, nothing to run
+    # command is also valid whan env variable is empty
+    if [ -z "$(ls -A $ODO_COMMAND_RUN_WORKING_DIR)" ]; then
+        return
+    fi
     if [ -z "$ODO_COMMAND_RUN" ]; then
         echo "ODO_COMMAND_RUN is not set";
     else

--- a/devfile-supervisor.conf
+++ b/devfile-supervisor.conf
@@ -6,7 +6,7 @@ stderr_logfile=/dev/stderr
 stderr_events_enabled=true
 stopasgroup=true
 killasgroup=true
-autostart=false
+autostart=true
 startretries=0
 
 [program:debugrun]


### PR DESCRIPTION
Fixes https://github.com/openshift/odo/issues/4822


How to test it:

- With non ephemeral source:
```
odo preference set Ephemeral false
ODO_BOOTSTRAPPER_IMAGE=quay.io/phmartin/odo-init-container:issue4822-2 odo push
odo exec -- kill 1
odo log # should show the app started
kubectl delete pod ...
# wait for new pod running
odo log # should show the app started
```

- With ephemeral source:
```
odo preference set Ephemeral true
ODO_BOOTSTRAPPER_IMAGE=quay.io/phmartin/odo-init-container:issue4822-2 odo push
odo exec -- kill 1
odo log # should show the app started
kubectl delete pod ...
# wait for new pod running
odo log # should show the app **not** started

# With patch https://github.com/openshift/odo/pull/5081 (needs to fix sync)
ODO_BOOTSTRAPPER_IMAGE=quay.io/phmartin/odo-init-container:issue4822-2 odo push
odo log # should show the app started
```
