### PR TITLE
update ubi to use latest go 1.17 for odo-init-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Build Go stuff (SupervisorD, go-init)
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7 AS gobuilder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7-13 AS gobuilder
 
 RUN mkdir -p /opt/app-root/src/go/src/github.com/ochinchina/supervisord
 ADD vendor/supervisord /opt/app-root/src/go/src/github.com/ochinchina/supervisord


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

Fixes: https://github.com/redhat-developer/odo/issues/5707

This will update the version of ubi golang image used to build odo-init-image.
Tests are passing on both v2 and main branch of odo.